### PR TITLE
docs: add workflow condition panel example

### DIFF
--- a/packages/docs/src/components/examples/workflow-condition-panel/index.tsx
+++ b/packages/docs/src/components/examples/workflow-condition-panel/index.tsx
@@ -1,0 +1,28 @@
+import {
+  FilterBuilder,
+  FilterSphereProvider,
+  useFilterSphere,
+} from "@fn-sphere/filter";
+import {
+  createWorkflowDefaultRule,
+  workflowFilterLabels,
+  workflowFilterList,
+  workflowSchema,
+} from "./schema";
+import { workflowPanelTheme } from "./theme";
+
+export function WorkflowConditionPanel() {
+  const { context } = useFilterSphere({
+    defaultRule: createWorkflowDefaultRule,
+    filterFnList: workflowFilterList,
+    getLocaleText: (key) => key,
+    mapFilterName: (filter) => workflowFilterLabels[filter.name] ?? filter.name,
+    schema: workflowSchema,
+  });
+
+  return (
+    <FilterSphereProvider context={context} theme={workflowPanelTheme}>
+      <FilterBuilder />
+    </FilterSphereProvider>
+  );
+}

--- a/packages/docs/src/components/examples/workflow-condition-panel/schema.ts
+++ b/packages/docs/src/components/examples/workflow-condition-panel/schema.ts
@@ -1,0 +1,72 @@
+import {
+  createFilterGroup,
+  createSingleFilter,
+  type FnSchema,
+  presetFilter,
+} from "@fn-sphere/filter";
+import { z } from "zod";
+
+const team = z.union([
+  z.literal("Design").describe("Design"),
+  z.literal("IT").describe("IT"),
+  z.literal("Research").describe("Research"),
+  z.literal("Operations").describe("Operations"),
+]);
+
+const position = z.union([
+  z.literal("Director").describe("Director"),
+  z.literal("Manager").describe("Manager"),
+  z.literal("Lead").describe("Lead"),
+  z.literal("Contributor").describe("Contributor"),
+]);
+
+const department = z.union([
+  z.literal("Management").describe("Management"),
+  z.literal("Product").describe("Product"),
+  z.literal("Engineering").describe("Engineering"),
+  z.literal("People").describe("People"),
+]);
+
+export const workflowSchema = z
+  .object({
+    team: team.describe("Team"),
+    position: position.describe("Position"),
+    department: department.describe("Department"),
+  })
+  .describe("New hire");
+
+export const workflowFilterList: FnSchema[] = presetFilter;
+
+export const createWorkflowDefaultRule = () =>
+  createFilterGroup({
+    op: "and",
+    conditions: [
+      createSingleFilter({
+        path: ["team"],
+        name: "contains",
+        args: [["Design", "IT", "Research"]],
+      }),
+      createFilterGroup({
+        op: "or",
+        conditions: [
+          createSingleFilter({
+            path: ["position"],
+            name: "contains",
+            args: [["Director", "Manager"]],
+          }),
+          createSingleFilter({
+            path: ["department"],
+            name: "notEqual",
+            args: ["Management"],
+          }),
+        ],
+      }),
+    ],
+  });
+
+export const workflowFilterLabels: Record<string, string> = {
+  contains: "is any of",
+  equals: "is",
+  notContains: "is none of",
+  notEqual: "is not",
+};

--- a/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
+++ b/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
@@ -6,6 +6,7 @@ import {
   useView,
   type FilterTheme,
 } from "@fn-sphere/filter";
+import * as Popover from "@radix-ui/react-popover";
 import {
   useCallback,
   useState,
@@ -13,7 +14,6 @@ import {
   type ChangeEvent,
   type ComponentType,
   type InputHTMLAttributes,
-  type MouseEvent,
   type ReactNode,
   type SelectHTMLAttributes,
 } from "react";
@@ -438,40 +438,29 @@ const templatesSpec = {
     const fieldName = String(selectedField?.path[0] ?? "");
     const FieldIcon = fieldIcons[fieldName] ?? BranchIcon;
     const canRemove = parentGroup.conditions.length > 1;
+    const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-    const closeMenu = useCallback((event: MouseEvent<HTMLButtonElement>) => {
-      event.currentTarget.closest("details")?.removeAttribute("open");
+    const handleMenuOpenChange = useCallback((open: boolean) => {
+      setIsMenuOpen(open);
     }, []);
 
-    const handleAddCondition = useCallback(
-      (event: MouseEvent<HTMLButtonElement>) => {
-        closeMenu(event);
-        appendRule();
-      },
-      [appendRule, closeMenu],
-    );
+    const handleAddCondition = useCallback(() => {
+      appendRule();
+    }, [appendRule]);
 
-    const handleAddGroup = useCallback(
-      (event: MouseEvent<HTMLButtonElement>) => {
-        closeMenu(event);
-        appendGroup();
-      },
-      [appendGroup, closeMenu],
-    );
+    const handleAddGroup = useCallback(() => {
+      appendGroup();
+    }, [appendGroup]);
 
-    const handleRemoveRule = useCallback(
-      (event: MouseEvent<HTMLButtonElement>) => {
-        closeMenu(event);
-        removeRule(true);
-      },
-      [closeMenu, removeRule],
-    );
+    const handleRemoveRule = useCallback(() => {
+      removeRule(true);
+    }, [removeRule]);
 
     return (
       <div className="group/filter-rule flex min-w-0 items-start">
         <div className="relative min-w-0 flex-1 rounded-lg border border-slate-200 bg-white shadow-[0_1px_3px_rgba(15,23,42,0.08)]">
           <div className="relative flex min-w-0 border-b border-slate-200">
-            <div className="flex min-w-0 flex-1 items-center gap-2 px-3">
+            <div className="flex min-w-0 flex-1 items-center gap-2 py-0 pl-3 pr-12">
               <FieldIcon className="h-4 w-4 shrink-0 text-slate-500" />
               <FieldSelect
                 aria-label="Field"
@@ -479,39 +468,67 @@ const templatesSpec = {
                 rule={rule}
               />
             </div>
-            <details className="absolute right-1 top-1 z-30 [&[open]>summary]:bg-slate-100 [&[open]>summary]:text-slate-700">
-              <summary
-                aria-label="Condition actions"
-                className="flex h-9 w-9 cursor-pointer list-none items-center justify-center rounded-md bg-transparent text-lg leading-none text-slate-400 opacity-0 transition hover:bg-slate-100 hover:text-slate-700 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-violet-500 group-hover/filter-rule:opacity-100 group-focus-within/filter-rule:opacity-100"
+            <div className="absolute right-1 top-1">
+              <Popover.Root
+                open={isMenuOpen}
+                onOpenChange={handleMenuOpenChange}
               >
-                ⋯
-              </summary>
-              <div className="absolute right-0 top-10 w-44 rounded-lg border border-slate-200 bg-white p-1 text-slate-900 shadow-lg">
-                <button
-                  className="h-8 w-full rounded-md border-0 bg-white px-2 text-left text-xs font-medium text-slate-700 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
-                  type="button"
-                  onClick={handleAddCondition}
-                >
-                  Add condition after
-                </button>
-                <button
-                  className="h-8 w-full rounded-md border-0 bg-white px-2 text-left text-xs font-medium text-slate-700 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
-                  type="button"
-                  onClick={handleAddGroup}
-                >
-                  Add group after
-                </button>
-                <div className="my-1 h-px bg-slate-200" />
-                <button
-                  className="h-8 w-full rounded-md border-0 bg-white px-2 text-left text-xs font-medium text-red-700 hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 disabled:cursor-not-allowed disabled:text-slate-300 disabled:hover:bg-white"
-                  disabled={!canRemove}
-                  type="button"
-                  onClick={handleRemoveRule}
-                >
-                  Delete condition
-                </button>
-              </div>
-            </details>
+                <Popover.Trigger asChild>
+                  <button
+                    aria-label="Condition actions"
+                    className={cx(
+                      "flex h-9 w-9 items-center justify-center rounded-md border-0 text-lg leading-none opacity-0 transition focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-violet-500 group-hover/filter-rule:opacity-100 group-focus-within/filter-rule:opacity-100",
+                      isMenuOpen
+                        ? "bg-slate-100 text-slate-700 opacity-100"
+                        : "bg-transparent text-slate-400 hover:bg-slate-100 hover:text-slate-700",
+                    )}
+                    type="button"
+                  >
+                    ⋯
+                  </button>
+                </Popover.Trigger>
+                <Popover.Portal>
+                  <Popover.Content
+                    align="end"
+                    aria-label="Condition actions"
+                    className="isolate w-44 rounded-lg border border-slate-200 bg-white p-1 text-slate-900 shadow-lg outline-none"
+                    collisionPadding={8}
+                    side="bottom"
+                    sideOffset={4}
+                  >
+                    <Popover.Close asChild>
+                      <button
+                        className="h-8 w-full rounded-md border-0 bg-white px-2 text-left text-xs font-medium text-slate-700 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
+                        type="button"
+                        onClick={handleAddCondition}
+                      >
+                        Add condition after
+                      </button>
+                    </Popover.Close>
+                    <Popover.Close asChild>
+                      <button
+                        className="h-8 w-full rounded-md border-0 bg-white px-2 text-left text-xs font-medium text-slate-700 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
+                        type="button"
+                        onClick={handleAddGroup}
+                      >
+                        Add group after
+                      </button>
+                    </Popover.Close>
+                    <div className="my-1 h-px bg-slate-200" />
+                    <Popover.Close asChild>
+                      <button
+                        className="h-8 w-full rounded-md border-0 bg-white px-2 text-left text-xs font-medium text-red-700 hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 disabled:cursor-not-allowed disabled:text-slate-300 disabled:hover:bg-white"
+                        disabled={!canRemove}
+                        type="button"
+                        onClick={handleRemoveRule}
+                      >
+                        Delete condition
+                      </button>
+                    </Popover.Close>
+                  </Popover.Content>
+                </Popover.Portal>
+              </Popover.Root>
+            </div>
           </div>
           <div className="grid min-w-0 grid-cols-1 divide-y divide-slate-200 sm:grid-cols-[minmax(110px,0.32fr)_1fr] sm:divide-x sm:divide-y-0">
             <FilterSelect

--- a/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
+++ b/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
@@ -320,7 +320,7 @@ const PanelMultipleSelect = <T,>({
         </Popover.Trigger>
         <Popover.Portal>
           <Popover.Content
-            align="end"
+            align="start"
             aria-label="Values"
             aria-multiselectable="true"
             className={selectPopoverContentClass}

--- a/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
+++ b/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
@@ -479,23 +479,23 @@ const templatesSpec = {
                 rule={rule}
               />
             </div>
-            <details className="absolute right-1 top-1 z-30">
+            <details className="absolute right-1 top-1 z-30 [&[open]>summary]:bg-slate-100 [&[open]>summary]:text-slate-700">
               <summary
                 aria-label="Condition actions"
-                className="flex h-9 w-9 cursor-pointer list-none items-center justify-center rounded-md bg-white text-lg leading-none text-slate-400 opacity-0 transition hover:bg-slate-50 hover:text-slate-700 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-violet-500 group-hover/filter-rule:opacity-100 group-focus-within/filter-rule:opacity-100"
+                className="flex h-9 w-9 cursor-pointer list-none items-center justify-center rounded-md bg-transparent text-lg leading-none text-slate-400 opacity-0 transition hover:bg-slate-100 hover:text-slate-700 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-violet-500 group-hover/filter-rule:opacity-100 group-focus-within/filter-rule:opacity-100"
               >
                 ⋯
               </summary>
-              <div className="absolute right-0 top-10 w-44 rounded-lg border border-slate-200 bg-white p-1 shadow-lg">
+              <div className="absolute right-0 top-10 w-44 rounded-lg border border-slate-200 bg-white p-1 text-slate-900 shadow-lg">
                 <button
-                  className="h-8 w-full rounded-md px-2 text-left text-xs font-medium text-slate-700 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
+                  className="h-8 w-full rounded-md border-0 bg-white px-2 text-left text-xs font-medium text-slate-700 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
                   type="button"
                   onClick={handleAddCondition}
                 >
                   Add condition after
                 </button>
                 <button
-                  className="h-8 w-full rounded-md px-2 text-left text-xs font-medium text-slate-700 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
+                  className="h-8 w-full rounded-md border-0 bg-white px-2 text-left text-xs font-medium text-slate-700 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
                   type="button"
                   onClick={handleAddGroup}
                 >
@@ -503,7 +503,7 @@ const templatesSpec = {
                 </button>
                 <div className="my-1 h-px bg-slate-200" />
                 <button
-                  className="h-8 w-full rounded-md px-2 text-left text-xs font-medium text-red-700 hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 disabled:cursor-not-allowed disabled:text-slate-300 disabled:hover:bg-transparent"
+                  className="h-8 w-full rounded-md border-0 bg-white px-2 text-left text-xs font-medium text-red-700 hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 disabled:cursor-not-allowed disabled:text-slate-300 disabled:hover:bg-white"
                   disabled={!canRemove}
                   type="button"
                   onClick={handleRemoveRule}

--- a/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
+++ b/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
@@ -57,6 +57,17 @@ const ValueToken = ({ children }: { children: ReactNode }) => (
   </span>
 );
 
+const selectPopoverContentClass =
+  "isolate w-52 max-w-[calc(100vw-16px)] rounded-lg border border-slate-200 bg-white p-1 text-slate-900 shadow-lg outline-none";
+
+const getSelectOptionClass = (isSelected: boolean) =>
+  cx(
+    "flex h-8 w-full items-center justify-between rounded-md border-0 px-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500",
+    isSelected
+      ? "bg-slate-100 text-slate-950 hover:bg-slate-200"
+      : "bg-white text-slate-700 hover:bg-slate-100",
+  );
+
 export const BranchIcon = ({ className }: IconProps) => (
   <svg aria-hidden="true" className={className} viewBox="0 0 24 24">
     <circle className={iconStroke} cx="6" cy="6" r="2.5" />
@@ -153,18 +164,20 @@ const PanelInput = ({
 
 const PanelSelect = <T,>({
   className,
+  disabled,
   onChange,
   options = [],
   value,
   ...props
 }: PanelSelectProps<T>) => {
-  const { "aria-label": ariaLabel, ...selectProps } = props;
+  const { "aria-label": ariaLabel } = props;
+  const [isOpen, setIsOpen] = useState(false);
   const selectedIdx = options.findIndex((option) => option.value === value);
   const selectedOption = options[selectedIdx];
   const isValueSelect = ariaLabel === undefined;
-  const handleChange = useCallback(
-    (event: ChangeEvent<HTMLSelectElement>) => {
-      const index = Number(event.target.value);
+  const resolvedAriaLabel = ariaLabel ?? "Value";
+  const handleSelect = useCallback(
+    (index: number) => {
       const selectedOption = options[index];
       if (selectedOption) {
         onChange?.(selectedOption.value);
@@ -173,59 +186,71 @@ const PanelSelect = <T,>({
     [onChange, options],
   );
 
-  if (isValueSelect) {
-    return (
-      <div
-        className={cx(
-          "relative flex min-h-11 min-w-0 items-center px-3 py-1.5",
-          className,
-        )}
-      >
-        {selectedOption ? (
-          <ValueToken>{selectedOption.label}</ValueToken>
-        ) : (
-          <span className="text-sm text-slate-400">Select value</span>
-        )}
-        <select
-          aria-label="Value"
-          className="absolute inset-0 h-full w-full cursor-pointer appearance-none opacity-0 disabled:cursor-not-allowed"
-          value={selectedIdx}
-          onChange={handleChange}
-          {...selectProps}
-        >
-          <option value={-1} disabled></option>
-          {options.map(({ label }, index) => (
-            <option key={label} value={index}>
-              {label}
-            </option>
-          ))}
-        </select>
-      </div>
-    );
-  }
-
-  const selectPadding = ariaLabel === "Field" ? "pl-0 pr-8" : "px-3 pr-8";
-
   return (
     <div className={cx("relative min-w-0", className)}>
-      <select
-        className={cx(
-          "h-11 w-full appearance-none rounded-none border-0 bg-transparent text-[15px] font-medium text-slate-900 outline-none focus:ring-0 disabled:cursor-not-allowed disabled:text-slate-400",
-          selectPadding,
-        )}
-        aria-label={ariaLabel}
-        value={selectedIdx}
-        onChange={handleChange}
-        {...selectProps}
-      >
-        <option value={-1} disabled></option>
-        {options.map(({ label }, index) => (
-          <option key={label} value={index}>
-            {label}
-          </option>
-        ))}
-      </select>
-      <ChevronDownIcon className="pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+      <Popover.Root open={isOpen} onOpenChange={setIsOpen}>
+        <Popover.Trigger asChild>
+          <button
+            aria-haspopup="listbox"
+            aria-label={resolvedAriaLabel}
+            className={cx(
+              "flex min-h-11 w-full min-w-0 items-center gap-2 border-0 bg-transparent text-left text-[15px] font-medium text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 disabled:cursor-not-allowed disabled:text-slate-400",
+              ariaLabel === "Field" ? "pl-0 pr-2" : "px-3",
+            )}
+            disabled={disabled}
+            type="button"
+          >
+            <span className="min-w-0 flex-1 truncate">
+              {selectedOption ? (
+                isValueSelect ? (
+                  <ValueToken>{selectedOption.label}</ValueToken>
+                ) : (
+                  selectedOption.label
+                )
+              ) : (
+                <span className="text-slate-400">Select value</span>
+              )}
+            </span>
+            <ChevronDownIcon className="h-4 w-4 shrink-0 text-slate-500" />
+          </button>
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Content
+            align="start"
+            aria-label={resolvedAriaLabel}
+            className={selectPopoverContentClass}
+            collisionPadding={8}
+            role="listbox"
+            side="bottom"
+            sideOffset={4}
+          >
+            {options.map((option, index) => {
+              const isSelected = index === selectedIdx;
+              return (
+                <Popover.Close asChild key={option.label}>
+                  <button
+                    aria-selected={isSelected}
+                    className={getSelectOptionClass(isSelected)}
+                    role="option"
+                    type="button"
+                    onClick={() => {
+                      handleSelect(index);
+                    }}
+                  >
+                    <span className="truncate">{option.label}</span>
+                    <CheckIcon
+                      className={cx(
+                        "h-4 w-4 shrink-0 text-slate-600",
+                        !isSelected && "invisible",
+                      )}
+                    />
+                  </button>
+                </Popover.Close>
+              );
+            })}
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover.Root>
     </div>
   );
 };
@@ -275,18 +300,22 @@ const PanelMultipleSelect = <T,>({
       <Popover.Root open={isOpen} onOpenChange={handleOpenChange}>
         <Popover.Trigger asChild>
           <button
+            aria-haspopup="listbox"
             aria-label="Values"
-            className="flex min-h-8 min-w-0 flex-1 flex-wrap items-center gap-1.5 border-0 bg-transparent p-0 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 disabled:cursor-not-allowed disabled:opacity-45"
+            className="flex min-h-8 min-w-0 flex-1 items-center gap-2 border-0 bg-transparent p-0 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 disabled:cursor-not-allowed disabled:opacity-45"
             disabled={disabled}
             type="button"
           >
-            {selectedOptions.length ? (
-              selectedOptions.map((option) => (
-                <ValueToken key={option.label}>{option.label}</ValueToken>
-              ))
-            ) : (
-              <span className="text-sm text-slate-400">Select values</span>
-            )}
+            <span className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+              {selectedOptions.length ? (
+                selectedOptions.map((option) => (
+                  <ValueToken key={option.label}>{option.label}</ValueToken>
+                ))
+              ) : (
+                <span className="text-sm text-slate-400">Select values</span>
+              )}
+            </span>
+            <ChevronDownIcon className="h-4 w-4 shrink-0 text-slate-500" />
           </button>
         </Popover.Trigger>
         <Popover.Portal>
@@ -294,7 +323,7 @@ const PanelMultipleSelect = <T,>({
             align="end"
             aria-label="Values"
             aria-multiselectable="true"
-            className="isolate w-[var(--radix-popover-trigger-width)] min-w-44 rounded-lg border border-slate-200 bg-white p-1 text-slate-900 shadow-lg outline-none"
+            className={selectPopoverContentClass}
             collisionPadding={8}
             role="listbox"
             side="bottom"
@@ -307,12 +336,7 @@ const PanelMultipleSelect = <T,>({
               return (
                 <button
                   aria-selected={isSelected}
-                  className={cx(
-                    "flex h-8 w-full items-center justify-between rounded-md border-0 px-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500",
-                    isSelected
-                      ? "bg-slate-100 text-slate-950 hover:bg-slate-200"
-                      : "bg-white text-slate-700 hover:bg-slate-100",
-                  )}
+                  className={getSelectOptionClass(isSelected)}
                   key={option.label}
                   role="option"
                   type="button"
@@ -320,7 +344,7 @@ const PanelMultipleSelect = <T,>({
                     handleToggle(option.value);
                   }}
                 >
-                  <span>{option.label}</span>
+                  <span className="truncate">{option.label}</span>
                   <CheckIcon
                     className={cx(
                       "h-4 w-4 text-slate-600",

--- a/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
+++ b/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
@@ -409,11 +409,15 @@ const templatesSpec = {
     }, [toggleGroupOp]);
 
     const hasMultipleConditions = rule.conditions.length > 1;
+    const lastCondition = rule.conditions.at(-1);
+    const endsWithNestedRail =
+      lastCondition?.type === "FilterGroup" &&
+      lastCondition.conditions.length > 1;
     const groupRail = hasMultipleConditions ? (
       <div
         className={cx(
           "pointer-events-none absolute left-6 top-4 w-4 rounded-l-xl border-y border-l border-slate-200",
-          isRoot ? "bottom-3" : "bottom-4",
+          endsWithNestedRail ? "bottom-7" : "bottom-4",
         )}
       />
     ) : null;

--- a/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
+++ b/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
@@ -73,6 +73,12 @@ export const ChevronDownIcon = ({ className }: IconProps) => (
   </svg>
 );
 
+const CheckIcon = ({ className }: IconProps) => (
+  <svg aria-hidden="true" className={className} viewBox="0 0 24 24">
+    <path className={iconStroke} d="m5 12 4 4 10-10" />
+  </svg>
+);
+
 const FolderPlusIcon = ({ className }: IconProps) => (
   <svg aria-hidden="true" className={className} viewBox="0 0 24 24">
     <path
@@ -236,12 +242,14 @@ const PanelMultipleSelect = <T,>({
     value.some((currentValue) => currentValue === option.value),
   );
 
-  const handleToggleOpen = useCallback(() => {
-    if (disabled) {
-      return;
-    }
-    setIsOpen((currentValue) => !currentValue);
-  }, [disabled]);
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!disabled) {
+        setIsOpen(open);
+      }
+    },
+    [disabled],
+  );
 
   const handleToggle = useCallback(
     (optionValue: T) => {
@@ -264,50 +272,67 @@ const PanelMultipleSelect = <T,>({
         className,
       )}
     >
-      <button
-        aria-expanded={isOpen}
-        aria-label="Values"
-        className="flex min-h-8 min-w-0 flex-1 flex-wrap items-center gap-1.5 border-0 bg-transparent p-0 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 disabled:cursor-not-allowed disabled:opacity-45"
-        disabled={disabled}
-        type="button"
-        onClick={handleToggleOpen}
-      >
-        {selectedOptions.length ? (
-          selectedOptions.map((option) => (
-            <ValueToken key={option.label}>{option.label}</ValueToken>
-          ))
-        ) : (
-          <span className="text-sm text-slate-400">Select values</span>
-        )}
-      </button>
-      {isOpen && (
-        <div className="absolute right-2 top-[calc(100%+4px)] z-30 min-w-44 rounded-lg border border-slate-200 bg-white p-1 shadow-lg">
-          {options.map((option) => {
-            const isSelected = value.some(
-              (currentValue) => currentValue === option.value,
-            );
-            return (
-              <button
-                aria-pressed={isSelected}
-                className={cx(
-                  "flex h-8 w-full items-center justify-between rounded-md border-0 px-2 text-sm font-medium transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500",
-                  isSelected
-                    ? "bg-slate-100 text-slate-950"
-                    : "bg-transparent text-slate-700",
-                )}
-                key={option.label}
-                type="button"
-                onClick={() => {
-                  handleToggle(option.value);
-                }}
-              >
-                {option.label}
-                {isSelected && <span className="text-slate-500">Selected</span>}
-              </button>
-            );
-          })}
-        </div>
-      )}
+      <Popover.Root open={isOpen} onOpenChange={handleOpenChange}>
+        <Popover.Trigger asChild>
+          <button
+            aria-label="Values"
+            className="flex min-h-8 min-w-0 flex-1 flex-wrap items-center gap-1.5 border-0 bg-transparent p-0 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 disabled:cursor-not-allowed disabled:opacity-45"
+            disabled={disabled}
+            type="button"
+          >
+            {selectedOptions.length ? (
+              selectedOptions.map((option) => (
+                <ValueToken key={option.label}>{option.label}</ValueToken>
+              ))
+            ) : (
+              <span className="text-sm text-slate-400">Select values</span>
+            )}
+          </button>
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Content
+            align="end"
+            aria-label="Values"
+            aria-multiselectable="true"
+            className="isolate w-[var(--radix-popover-trigger-width)] min-w-44 rounded-lg border border-slate-200 bg-white p-1 text-slate-900 shadow-lg outline-none"
+            collisionPadding={8}
+            role="listbox"
+            side="bottom"
+            sideOffset={4}
+          >
+            {options.map((option) => {
+              const isSelected = value.some(
+                (currentValue) => currentValue === option.value,
+              );
+              return (
+                <button
+                  aria-selected={isSelected}
+                  className={cx(
+                    "flex h-8 w-full items-center justify-between rounded-md border-0 px-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500",
+                    isSelected
+                      ? "bg-slate-100 text-slate-950 hover:bg-slate-200"
+                      : "bg-white text-slate-700 hover:bg-slate-100",
+                  )}
+                  key={option.label}
+                  role="option"
+                  type="button"
+                  onClick={() => {
+                    handleToggle(option.value);
+                  }}
+                >
+                  <span>{option.label}</span>
+                  <CheckIcon
+                    className={cx(
+                      "h-4 w-4 text-slate-600",
+                      !isSelected && "invisible",
+                    )}
+                  />
+                </button>
+              );
+            })}
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover.Root>
     </div>
   );
 };

--- a/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
+++ b/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
@@ -410,7 +410,12 @@ const templatesSpec = {
 
     const hasMultipleConditions = rule.conditions.length > 1;
     const groupRail = hasMultipleConditions ? (
-      <div className="pointer-events-none absolute bottom-4 left-6 top-4 w-4 rounded-l-xl border-y border-l border-slate-200" />
+      <div
+        className={cx(
+          "pointer-events-none absolute left-6 top-4 w-4 rounded-l-xl border-y border-l border-slate-200",
+          isRoot ? "bottom-3" : "bottom-4",
+        )}
+      />
     ) : null;
     const groupOperator = hasMultipleConditions ? (
       <button

--- a/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
+++ b/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
@@ -1,14 +1,14 @@
 import {
   createFilterTheme,
-  presetTheme,
   useFilterGroup,
   useFilterRule,
   useView,
+  type FilterGroup,
   type FilterTheme,
 } from "@fn-sphere/filter";
 import * as Popover from "@radix-ui/react-popover";
+import * as SelectPrimitive from "@radix-ui/react-select";
 import {
-  useCallback,
   useState,
   type ButtonHTMLAttributes,
   type ChangeEvent,
@@ -60,15 +60,10 @@ const ValueToken = ({ children }: { children: ReactNode }) => (
 const selectPopoverContentClass =
   "isolate w-52 max-w-[calc(100vw-16px)] rounded-lg border border-slate-200 bg-white p-1 text-slate-900 shadow-lg outline-none";
 
-const getSelectOptionClass = (isSelected: boolean) =>
-  cx(
-    "flex h-8 w-full items-center justify-between rounded-md border-0 px-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500",
-    isSelected
-      ? "bg-slate-100 text-slate-950 hover:bg-slate-200"
-      : "bg-white text-slate-700 hover:bg-slate-100",
-  );
+const selectOptionClass =
+  "flex h-8 w-full items-center justify-between rounded-md border-0 bg-white px-2 text-sm font-medium text-slate-700 outline-none transition hover:bg-slate-100 focus-visible:ring-2 focus-visible:ring-violet-500 data-[highlighted]:bg-slate-100 data-[state=checked]:bg-slate-100 data-[state=checked]:text-slate-950 data-[state=checked]:hover:bg-slate-200";
 
-export const BranchIcon = ({ className }: IconProps) => (
+const BranchIcon = ({ className }: IconProps) => (
   <svg aria-hidden="true" className={className} viewBox="0 0 24 24">
     <circle className={iconStroke} cx="6" cy="6" r="2.5" />
     <circle className={iconStroke} cx="18" cy="18" r="2.5" />
@@ -78,7 +73,7 @@ export const BranchIcon = ({ className }: IconProps) => (
   </svg>
 );
 
-export const ChevronDownIcon = ({ className }: IconProps) => (
+const ChevronDownIcon = ({ className }: IconProps) => (
   <svg aria-hidden="true" className={className} viewBox="0 0 24 24">
     <path className={iconStroke} d="m6 9 6 6 6-6" />
   </svg>
@@ -143,12 +138,9 @@ const PanelInput = ({
 }: Omit<InputHTMLAttributes<HTMLInputElement>, "onChange"> & {
   onChange?: (value: string) => void;
 }) => {
-  const handleChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      onChange?.(event.target.value);
-    },
-    [onChange],
-  );
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange?.(event.target.value);
+  };
 
   return (
     <input
@@ -163,94 +155,81 @@ const PanelInput = ({
 };
 
 const PanelSelect = <T,>({
+  "aria-label": ariaLabel,
   className,
   disabled,
   onChange,
   options = [],
   value,
-  ...props
 }: PanelSelectProps<T>) => {
-  const { "aria-label": ariaLabel } = props;
-  const [isOpen, setIsOpen] = useState(false);
   const selectedIdx = options.findIndex((option) => option.value === value);
   const selectedOption = options[selectedIdx];
   const isValueSelect = ariaLabel === undefined;
   const resolvedAriaLabel = ariaLabel ?? "Value";
-  const handleSelect = useCallback(
-    (index: number) => {
-      const selectedOption = options[index];
-      if (selectedOption) {
-        onChange?.(selectedOption.value);
-      }
-    },
-    [onChange, options],
-  );
+  const handleValueChange = (nextValue: string) => {
+    const selectedOption = options[Number(nextValue)];
+    if (selectedOption) {
+      onChange?.(selectedOption.value);
+    }
+  };
 
   return (
-    <div className={cx("relative min-w-0", className)}>
-      <Popover.Root open={isOpen} onOpenChange={setIsOpen}>
-        <Popover.Trigger asChild>
-          <button
-            aria-haspopup="listbox"
-            aria-label={resolvedAriaLabel}
-            className={cx(
-              "flex min-h-11 w-full min-w-0 items-center gap-2 border-0 bg-transparent text-left text-[15px] font-medium text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 disabled:cursor-not-allowed disabled:text-slate-400",
-              ariaLabel === "Field" ? "pl-0 pr-2" : "px-3",
-            )}
-            disabled={disabled}
-            type="button"
-          >
-            <span className="min-w-0 flex-1 truncate">
-              {selectedOption ? (
-                isValueSelect ? (
-                  <ValueToken>{selectedOption.label}</ValueToken>
-                ) : (
-                  selectedOption.label
-                )
+    <div className={cx("min-w-0", className)}>
+      <SelectPrimitive.Root
+        disabled={!!disabled}
+        value={selectedIdx >= 0 ? String(selectedIdx) : ""}
+        onValueChange={handleValueChange}
+      >
+        <SelectPrimitive.Trigger
+          aria-label={resolvedAriaLabel}
+          className={cx(
+            "flex min-h-11 w-full min-w-0 items-center gap-2 border-0 bg-transparent text-left text-[15px] font-medium text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 disabled:cursor-not-allowed disabled:text-slate-400",
+            ariaLabel === "Field" ? "pl-0 pr-2" : "px-3",
+          )}
+        >
+          <span className="min-w-0 flex-1 truncate">
+            {selectedOption ? (
+              isValueSelect ? (
+                <ValueToken>{selectedOption.label}</ValueToken>
               ) : (
-                <span className="text-slate-400">Select value</span>
-              )}
-            </span>
+                selectedOption.label
+              )
+            ) : (
+              <span className="text-slate-400">Select value</span>
+            )}
+          </span>
+          <SelectPrimitive.Icon asChild>
             <ChevronDownIcon className="h-4 w-4 shrink-0 text-slate-500" />
-          </button>
-        </Popover.Trigger>
-        <Popover.Portal>
-          <Popover.Content
+          </SelectPrimitive.Icon>
+        </SelectPrimitive.Trigger>
+        <SelectPrimitive.Portal>
+          <SelectPrimitive.Content
             align="start"
-            aria-label={resolvedAriaLabel}
             className={selectPopoverContentClass}
             collisionPadding={8}
-            role="listbox"
+            position="popper"
             side="bottom"
             sideOffset={4}
           >
-            {options.map((option, index) => {
-              const isSelected = index === selectedIdx;
-              return (
-                <Popover.Close asChild key={option.label}>
-                  <button
-                    aria-selected={isSelected}
-                    className={getSelectOptionClass(isSelected)}
-                    role="option"
-                    type="button"
-                    onClick={() => {
-                      handleSelect(index);
-                    }}
-                  >
+            <SelectPrimitive.Viewport>
+              {options.map((option, index) => (
+                <SelectPrimitive.Item
+                  className={selectOptionClass}
+                  key={option.label}
+                  value={String(index)}
+                >
+                  <SelectPrimitive.ItemText asChild>
                     <span className="truncate">{option.label}</span>
-                    <CheckIcon
-                      className={cx(
-                        "h-4 w-4 shrink-0 text-slate-600",
-                        !isSelected && "invisible",
-                      )}
-                    />
-                  </button>
-                </Popover.Close>
-              );
-            })}
-          </Popover.Content>
-        </Popover.Portal>
-      </Popover.Root>
+                  </SelectPrimitive.ItemText>
+                  <SelectPrimitive.ItemIndicator asChild>
+                    <CheckIcon className="h-4 w-4 shrink-0 text-slate-600" />
+                  </SelectPrimitive.ItemIndicator>
+                </SelectPrimitive.Item>
+              ))}
+            </SelectPrimitive.Viewport>
+          </SelectPrimitive.Content>
+        </SelectPrimitive.Portal>
+      </SelectPrimitive.Root>
     </div>
   );
 };
@@ -262,45 +241,28 @@ const PanelMultipleSelect = <T,>({
   options = [],
   value = [],
 }: PanelMultiSelectProps<T>) => {
-  const [isOpen, setIsOpen] = useState(false);
   const selectedOptions = options.filter((option) =>
     value.some((currentValue) => currentValue === option.value),
   );
 
-  const handleOpenChange = useCallback(
-    (open: boolean) => {
-      if (!disabled) {
-        setIsOpen(open);
-      }
-    },
-    [disabled],
-  );
-
-  const handleToggle = useCallback(
-    (optionValue: T) => {
-      const hasValue = value.some(
-        (currentValue) => currentValue === optionValue,
-      );
-      const nextValue = hasValue
-        ? value.filter((currentValue) => currentValue !== optionValue)
-        : [...value, optionValue];
-      onChange?.(nextValue);
-    },
-    [onChange, value],
-  );
+  const handleToggle = (optionValue: T) => {
+    const hasValue = value.some((currentValue) => currentValue === optionValue);
+    const nextValue = hasValue
+      ? value.filter((currentValue) => currentValue !== optionValue)
+      : [...value, optionValue];
+    onChange?.(nextValue);
+  };
 
   return (
     <div
-      aria-disabled={disabled}
       className={cx(
-        "relative flex min-h-11 min-w-0 items-center px-3 py-1.5",
+        "flex min-h-11 min-w-0 items-center px-3 py-1.5",
         className,
       )}
     >
-      <Popover.Root open={isOpen} onOpenChange={handleOpenChange}>
+      <Popover.Root>
         <Popover.Trigger asChild>
           <button
-            aria-haspopup="listbox"
             aria-label="Values"
             className="flex min-h-8 min-w-0 flex-1 items-center gap-2 border-0 bg-transparent p-0 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 disabled:cursor-not-allowed disabled:opacity-45"
             disabled={disabled}
@@ -322,10 +284,8 @@ const PanelMultipleSelect = <T,>({
           <Popover.Content
             align="start"
             aria-label="Values"
-            aria-multiselectable="true"
             className={selectPopoverContentClass}
             collisionPadding={8}
-            role="listbox"
             side="bottom"
             sideOffset={4}
           >
@@ -335,10 +295,10 @@ const PanelMultipleSelect = <T,>({
               );
               return (
                 <button
-                  aria-selected={isSelected}
-                  className={getSelectOptionClass(isSelected)}
+                  aria-pressed={isSelected}
+                  className={selectOptionClass}
+                  data-state={isSelected ? "checked" : "unchecked"}
                   key={option.label}
-                  role="option"
                   type="button"
                   onClick={() => {
                     handleToggle(option.value);
@@ -387,45 +347,37 @@ const AddButton = ({
   </button>
 );
 
+const getRailBottomInset = (group: FilterGroup): number => {
+  const lastCondition = group.conditions.at(-1);
+  return lastCondition?.type === "FilterGroup" &&
+    lastCondition.conditions.length > 1
+    ? 12 + getRailBottomInset(lastCondition)
+    : 16;
+};
+
 const templatesSpec = {
   FilterGroupContainer: ({ children, rule, ...props }) => {
     const {
-      ruleState: { depth, isRoot },
+      ruleState: { isRoot },
       appendChildGroup,
       appendChildRule,
       toggleGroupOp,
     } = useFilterGroup(rule);
 
-    const handleAddCondition = useCallback(() => {
-      appendChildRule();
-    }, [appendChildRule]);
-
-    const handleAddGroup = useCallback(() => {
-      appendChildGroup();
-    }, [appendChildGroup]);
-
-    const handleToggleGroupOp = useCallback(() => {
-      toggleGroupOp();
-    }, [toggleGroupOp]);
-
     const hasMultipleConditions = rule.conditions.length > 1;
-    const lastCondition = rule.conditions.at(-1);
-    const endsWithNestedRail =
-      lastCondition?.type === "FilterGroup" &&
-      lastCondition.conditions.length > 1;
     const groupRail = hasMultipleConditions ? (
       <div
-        className={cx(
-          "pointer-events-none absolute left-6 top-4 w-4 rounded-l-xl border-y border-l border-slate-200",
-          endsWithNestedRail ? "bottom-7" : "bottom-4",
-        )}
+        className="pointer-events-none absolute left-6 top-4 w-4 rounded-l-xl border-y border-l border-slate-200"
+        style={{ bottom: getRailBottomInset(rule) }}
       />
     ) : null;
     const groupOperator = hasMultipleConditions ? (
       <button
         className="absolute left-6 top-1/2 inline-flex h-6 -translate-x-1/2 -translate-y-1/2 items-center rounded-md border border-slate-200 bg-white px-2 text-xs font-medium text-slate-600 shadow-sm transition hover:border-violet-200 hover:text-violet-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
         type="button"
-        onClick={handleToggleGroupOp}
+        onClick={() => {
+          toggleGroupOp();
+        }}
       >
         {rule.op === "and" ? "And" : "Or"}
       </button>
@@ -447,18 +399,20 @@ const templatesSpec = {
           <div className="mt-5 flex flex-wrap gap-2">
             <AddButton
               icon={<BranchIcon className="h-4 w-4 text-slate-900" />}
-              onClick={handleAddCondition}
+              onClick={() => {
+                appendChildRule();
+              }}
             >
               Add condition
             </AddButton>
-            {depth < 4 && (
-              <AddButton
-                icon={<FolderPlusIcon className="h-4 w-4 text-slate-900" />}
-                onClick={handleAddGroup}
-              >
-                Add group
-              </AddButton>
-            )}
+            <AddButton
+              icon={<FolderPlusIcon className="h-4 w-4 text-slate-900" />}
+              onClick={() => {
+                appendChildGroup();
+              }}
+            >
+              Add group
+            </AddButton>
           </div>
         </div>
       );
@@ -478,41 +432,15 @@ const templatesSpec = {
       </div>
     );
   },
-  FilterSelect: (props) => {
-    const PresetFilterSelect = presetTheme.templates.FilterSelect;
-    return <PresetFilterSelect tryRetainArgs {...props} />;
-  },
   RuleJoiner: () => null,
   SingleFilter: ({ rule }) => {
     const { FieldSelect, FilterDataInput, FilterSelect } = useView("templates");
-    const {
-      ruleState: { parentGroup },
-      appendGroup,
-      appendRule,
-      removeRule,
-      selectedField,
-    } = useFilterRule(rule);
+    const { appendGroup, appendRule, removeRule, selectedField } =
+      useFilterRule(rule);
 
     const fieldName = String(selectedField?.path[0] ?? "");
     const FieldIcon = fieldIcons[fieldName] ?? BranchIcon;
-    const canRemove = parentGroup.conditions.length > 1;
     const [isMenuOpen, setIsMenuOpen] = useState(false);
-
-    const handleMenuOpenChange = useCallback((open: boolean) => {
-      setIsMenuOpen(open);
-    }, []);
-
-    const handleAddCondition = useCallback(() => {
-      appendRule();
-    }, [appendRule]);
-
-    const handleAddGroup = useCallback(() => {
-      appendGroup();
-    }, [appendGroup]);
-
-    const handleRemoveRule = useCallback(() => {
-      removeRule(true);
-    }, [removeRule]);
 
     return (
       <div className="group/filter-rule flex min-w-0 items-start">
@@ -527,10 +455,7 @@ const templatesSpec = {
               />
             </div>
             <div className="absolute right-1 top-1">
-              <Popover.Root
-                open={isMenuOpen}
-                onOpenChange={handleMenuOpenChange}
-              >
+              <Popover.Root open={isMenuOpen} onOpenChange={setIsMenuOpen}>
                 <Popover.Trigger asChild>
                   <button
                     aria-label="Condition actions"
@@ -558,7 +483,9 @@ const templatesSpec = {
                       <button
                         className="h-8 w-full rounded-md border-0 bg-white px-2 text-left text-xs font-medium text-slate-700 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
                         type="button"
-                        onClick={handleAddCondition}
+                        onClick={() => {
+                          appendRule();
+                        }}
                       >
                         Add condition after
                       </button>
@@ -567,7 +494,9 @@ const templatesSpec = {
                       <button
                         className="h-8 w-full rounded-md border-0 bg-white px-2 text-left text-xs font-medium text-slate-700 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
                         type="button"
-                        onClick={handleAddGroup}
+                        onClick={() => {
+                          appendGroup();
+                        }}
                       >
                         Add group after
                       </button>
@@ -575,10 +504,11 @@ const templatesSpec = {
                     <div className="my-1 h-px bg-slate-200" />
                     <Popover.Close asChild>
                       <button
-                        className="h-8 w-full rounded-md border-0 bg-white px-2 text-left text-xs font-medium text-red-700 hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 disabled:cursor-not-allowed disabled:text-slate-300 disabled:hover:bg-white"
-                        disabled={!canRemove}
+                        className="h-8 w-full rounded-md border-0 bg-white px-2 text-left text-xs font-medium text-red-700 hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
                         type="button"
-                        onClick={handleRemoveRule}
+                        onClick={() => {
+                          removeRule(true);
+                        }}
                       >
                         Delete condition
                       </button>

--- a/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
+++ b/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
@@ -1,0 +1,511 @@
+import {
+  createFilterTheme,
+  presetTheme,
+  useFilterGroup,
+  useFilterRule,
+  useView,
+  type FilterTheme,
+} from "@fn-sphere/filter";
+import {
+  useCallback,
+  useState,
+  type ButtonHTMLAttributes,
+  type ChangeEvent,
+  type ComponentType,
+  type InputHTMLAttributes,
+  type ReactNode,
+  type SelectHTMLAttributes,
+} from "react";
+
+type IconProps = {
+  className?: string;
+};
+
+type SelectOption<T> = {
+  label: string;
+  value: T;
+};
+
+type PanelSelectProps<T> = Omit<
+  SelectHTMLAttributes<HTMLSelectElement>,
+  "children" | "multiple" | "onChange" | "value"
+> & {
+  onChange?: ((value: T) => void) | undefined;
+  options?: SelectOption<T>[] | undefined;
+  value?: T | undefined;
+};
+
+type PanelMultiSelectProps<T> = Omit<
+  SelectHTMLAttributes<HTMLSelectElement>,
+  "children" | "multiple" | "onChange" | "value"
+> & {
+  onChange?: ((value: T[]) => void) | undefined;
+  options?: SelectOption<T>[] | undefined;
+  value?: T[] | undefined;
+};
+
+const cx = (...parts: Array<string | false | null | undefined>) =>
+  parts.filter(Boolean).join(" ");
+
+const iconStroke =
+  "fill-none stroke-current stroke-[1.8] [stroke-linecap:round] [stroke-linejoin:round]";
+
+const ValueToken = ({ children }: { children: ReactNode }) => (
+  <span className="inline-flex min-h-8 items-center rounded-md bg-slate-200 px-2 text-[15px] font-medium leading-none text-slate-900 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.35)]">
+    {children}
+  </span>
+);
+
+export const BranchIcon = ({ className }: IconProps) => (
+  <svg aria-hidden="true" className={className} viewBox="0 0 24 24">
+    <circle className={iconStroke} cx="6" cy="6" r="2.5" />
+    <circle className={iconStroke} cx="18" cy="18" r="2.5" />
+    <circle className={iconStroke} cx="6" cy="18" r="2.5" />
+    <path className={iconStroke} d="M8.5 6c5 0 7.5 2.5 7.5 9.5" />
+    <path className={iconStroke} d="M8.5 18H15" />
+  </svg>
+);
+
+export const ChevronDownIcon = ({ className }: IconProps) => (
+  <svg aria-hidden="true" className={className} viewBox="0 0 24 24">
+    <path className={iconStroke} d="m6 9 6 6 6-6" />
+  </svg>
+);
+
+const CloseIcon = ({ className }: IconProps) => (
+  <svg aria-hidden="true" className={className} viewBox="0 0 24 24">
+    <path className={iconStroke} d="M18 6 6 18" />
+    <path className={iconStroke} d="m6 6 12 12" />
+  </svg>
+);
+
+const FolderPlusIcon = ({ className }: IconProps) => (
+  <svg aria-hidden="true" className={className} viewBox="0 0 24 24">
+    <path
+      className={iconStroke}
+      d="M3 7.5A2.5 2.5 0 0 1 5.5 5H10l2 2h6.5A2.5 2.5 0 0 1 21 9.5v7A2.5 2.5 0 0 1 18.5 19h-13A2.5 2.5 0 0 1 3 16.5z"
+    />
+    <path className={iconStroke} d="M12 11v5" />
+    <path className={iconStroke} d="M9.5 13.5h5" />
+  </svg>
+);
+
+const GripIcon = ({ className }: IconProps) => (
+  <svg aria-hidden="true" className={className} viewBox="0 0 24 24">
+    <path
+      className="fill-current"
+      d="M9 7.5a1.2 1.2 0 1 1-2.4 0 1.2 1.2 0 0 1 2.4 0Zm0 4.5a1.2 1.2 0 1 1-2.4 0A1.2 1.2 0 0 1 9 12Zm0 4.5a1.2 1.2 0 1 1-2.4 0 1.2 1.2 0 0 1 2.4 0Zm8.4-9a1.2 1.2 0 1 1-2.4 0 1.2 1.2 0 0 1 2.4 0Zm0 4.5a1.2 1.2 0 1 1-2.4 0 1.2 1.2 0 0 1 2.4 0Zm0 4.5a1.2 1.2 0 1 1-2.4 0 1.2 1.2 0 0 1 2.4 0Z"
+    />
+  </svg>
+);
+
+const UserIcon = ({ className }: IconProps) => (
+  <svg aria-hidden="true" className={className} viewBox="0 0 24 24">
+    <circle className={iconStroke} cx="12" cy="8" r="3" />
+    <path className={iconStroke} d="M5.5 20a6.5 6.5 0 0 1 13 0" />
+  </svg>
+);
+
+const UsersIcon = ({ className }: IconProps) => (
+  <svg aria-hidden="true" className={className} viewBox="0 0 24 24">
+    <circle className={iconStroke} cx="9" cy="8" r="2.5" />
+    <path className={iconStroke} d="M3.5 19a5.5 5.5 0 0 1 11 0" />
+    <path className={iconStroke} d="M16 10.5a2.5 2.5 0 1 0-.4-4.95" />
+    <path className={iconStroke} d="M17 14a5.2 5.2 0 0 1 3.5 5" />
+  </svg>
+);
+
+const fieldIcons: Record<string, ComponentType<IconProps>> = {
+  department: UsersIcon,
+  position: UserIcon,
+  team: UsersIcon,
+};
+
+const PanelButton = ({
+  className,
+  ...props
+}: ButtonHTMLAttributes<HTMLButtonElement>) => (
+  <button
+    className={cx(
+      "inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-slate-900 shadow-sm transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 disabled:pointer-events-none disabled:opacity-45",
+      className,
+    )}
+    {...props}
+  />
+);
+
+const PanelInput = ({
+  className,
+  onChange,
+  ...props
+}: Omit<InputHTMLAttributes<HTMLInputElement>, "onChange"> & {
+  onChange?: (value: string) => void;
+}) => {
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      onChange?.(event.target.value);
+    },
+    [onChange],
+  );
+
+  return (
+    <input
+      className={cx(
+        "h-10 min-w-0 rounded-none border-0 bg-transparent px-3 text-sm text-slate-900 outline-none placeholder:text-slate-400 focus:ring-0 disabled:cursor-not-allowed disabled:text-slate-400",
+        className,
+      )}
+      onChange={handleChange}
+      {...props}
+    />
+  );
+};
+
+const PanelSelect = <T,>({
+  className,
+  onChange,
+  options = [],
+  value,
+  ...props
+}: PanelSelectProps<T>) => {
+  const { "aria-label": ariaLabel, ...selectProps } = props;
+  const selectedIdx = options.findIndex((option) => option.value === value);
+  const selectedOption = options[selectedIdx];
+  const isValueSelect = ariaLabel === undefined;
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      const index = Number(event.target.value);
+      const selectedOption = options[index];
+      if (selectedOption) {
+        onChange?.(selectedOption.value);
+      }
+    },
+    [onChange, options],
+  );
+
+  if (isValueSelect) {
+    return (
+      <div
+        className={cx(
+          "relative flex min-h-11 min-w-0 items-center px-3 py-1.5",
+          className,
+        )}
+      >
+        {selectedOption ? (
+          <ValueToken>{selectedOption.label}</ValueToken>
+        ) : (
+          <span className="text-sm text-slate-400">Select value</span>
+        )}
+        <select
+          aria-label="Value"
+          className="absolute inset-0 h-full w-full cursor-pointer appearance-none opacity-0 disabled:cursor-not-allowed"
+          value={selectedIdx}
+          onChange={handleChange}
+          {...selectProps}
+        >
+          <option value={-1} disabled></option>
+          {options.map(({ label }, index) => (
+            <option key={label} value={index}>
+              {label}
+            </option>
+          ))}
+        </select>
+      </div>
+    );
+  }
+
+  const selectPadding = ariaLabel === "Field" ? "pl-0 pr-8" : "px-3 pr-8";
+
+  return (
+    <div className={cx("relative min-w-0", className)}>
+      <select
+        className={cx(
+          "h-11 w-full appearance-none rounded-none border-0 bg-transparent text-[15px] font-medium text-slate-900 outline-none focus:ring-0 disabled:cursor-not-allowed disabled:text-slate-400",
+          selectPadding,
+        )}
+        aria-label={ariaLabel}
+        value={selectedIdx}
+        onChange={handleChange}
+        {...selectProps}
+      >
+        <option value={-1} disabled></option>
+        {options.map(({ label }, index) => (
+          <option key={label} value={index}>
+            {label}
+          </option>
+        ))}
+      </select>
+      <ChevronDownIcon className="pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+    </div>
+  );
+};
+
+const PanelMultipleSelect = <T,>({
+  className,
+  disabled,
+  onChange,
+  options = [],
+  value = [],
+}: PanelMultiSelectProps<T>) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const selectedOptions = options.filter((option) =>
+    value.some((currentValue) => currentValue === option.value),
+  );
+
+  const handleToggleOpen = useCallback(() => {
+    if (disabled) {
+      return;
+    }
+    setIsOpen((currentValue) => !currentValue);
+  }, [disabled]);
+
+  const handleToggle = useCallback(
+    (optionValue: T) => {
+      const hasValue = value.some(
+        (currentValue) => currentValue === optionValue,
+      );
+      const nextValue = hasValue
+        ? value.filter((currentValue) => currentValue !== optionValue)
+        : [...value, optionValue];
+      onChange?.(nextValue);
+    },
+    [onChange, value],
+  );
+
+  return (
+    <div
+      aria-disabled={disabled}
+      className={cx(
+        "relative flex min-h-11 min-w-0 items-center px-3 py-1.5",
+        className,
+      )}
+    >
+      <button
+        aria-expanded={isOpen}
+        aria-label="Values"
+        className="flex min-h-8 min-w-0 flex-1 flex-wrap items-center gap-1.5 border-0 bg-transparent p-0 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 disabled:cursor-not-allowed disabled:opacity-45"
+        disabled={disabled}
+        type="button"
+        onClick={handleToggleOpen}
+      >
+        {selectedOptions.length ? (
+          selectedOptions.map((option) => (
+            <ValueToken key={option.label}>{option.label}</ValueToken>
+          ))
+        ) : (
+          <span className="text-sm text-slate-400">Select values</span>
+        )}
+      </button>
+      {isOpen && (
+        <div className="absolute right-2 top-[calc(100%+4px)] z-30 min-w-44 rounded-lg border border-slate-200 bg-white p-1 shadow-lg">
+          {options.map((option) => {
+            const isSelected = value.some(
+              (currentValue) => currentValue === option.value,
+            );
+            return (
+              <button
+                aria-pressed={isSelected}
+                className={cx(
+                  "flex h-8 w-full items-center justify-between rounded-md border-0 px-2 text-sm font-medium transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500",
+                  isSelected
+                    ? "bg-slate-100 text-slate-950"
+                    : "bg-transparent text-slate-700",
+                )}
+                key={option.label}
+                type="button"
+                onClick={() => {
+                  handleToggle(option.value);
+                }}
+              >
+                {option.label}
+                {isSelected && <span className="text-slate-500">Selected</span>}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const componentsSpec = {
+  Button: PanelButton,
+  Input: PanelInput,
+  MultipleSelect: PanelMultipleSelect,
+  Select: PanelSelect,
+} satisfies Partial<FilterTheme["components"]>;
+
+const AddButton = ({
+  children,
+  icon,
+  onClick,
+}: {
+  children: ReactNode;
+  icon: ReactNode;
+  onClick: () => void;
+}) => (
+  <button
+    className="inline-flex h-11 items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 text-[15px] font-semibold text-slate-900 shadow-sm transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
+    type="button"
+    onClick={onClick}
+  >
+    {icon}
+    {children}
+  </button>
+);
+
+const templatesSpec = {
+  FilterGroupContainer: ({ children, rule, ...props }) => {
+    const {
+      ruleState: { depth, isRoot },
+      appendChildGroup,
+      appendChildRule,
+      removeGroup,
+    } = useFilterGroup(rule);
+
+    const handleAddCondition = useCallback(() => {
+      appendChildRule();
+    }, [appendChildRule]);
+
+    const handleAddGroup = useCallback(() => {
+      appendChildGroup();
+    }, [appendChildGroup]);
+
+    const handleRemoveGroup = useCallback(() => {
+      removeGroup();
+    }, [removeGroup]);
+
+    if (isRoot) {
+      return (
+        <div {...props}>
+          <div className="relative flex flex-col gap-3 rounded-xl border border-slate-100 bg-slate-50 py-3 pl-10 pr-3">
+            <div className="pointer-events-none absolute bottom-4 left-4 top-4 w-6 rounded-l-xl border-y border-l border-slate-200" />
+            {children}
+          </div>
+          <div className="mt-5 flex flex-wrap gap-2">
+            <AddButton
+              icon={<BranchIcon className="h-4 w-4 text-slate-900" />}
+              onClick={handleAddCondition}
+            >
+              Add condition
+            </AddButton>
+            {depth < 4 && (
+              <AddButton
+                icon={<FolderPlusIcon className="h-4 w-4 text-slate-900" />}
+                onClick={handleAddGroup}
+              >
+                Add group
+              </AddButton>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div
+        className="group/filter-group relative flex flex-col gap-3 rounded-xl border border-slate-100 bg-slate-50 py-3 pl-10 pr-3"
+        {...props}
+      >
+        <div className="pointer-events-none absolute bottom-4 left-4 top-4 w-6 rounded-l-xl border-y border-l border-slate-200" />
+        <button
+          aria-label="Remove group"
+          className="absolute right-0 top-0 hidden h-7 w-7 items-center justify-center rounded-md text-slate-400 transition hover:bg-slate-100 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 group-hover/filter-group:flex"
+          type="button"
+          onClick={handleRemoveGroup}
+        >
+          <CloseIcon className="h-4 w-4" />
+        </button>
+        {children}
+      </div>
+    );
+  },
+  FilterSelect: (props) => {
+    const PresetFilterSelect = presetTheme.templates.FilterSelect;
+    return <PresetFilterSelect tryRetainArgs {...props} />;
+  },
+  RuleJoiner: ({ parent }) => {
+    const { toggleGroupOp } = useFilterGroup(parent);
+    const label = parent.op === "and" ? "And" : "Or";
+    const handleToggleGroupOp = useCallback(() => {
+      toggleGroupOp();
+    }, [toggleGroupOp]);
+
+    return (
+      <div className="relative h-2">
+        <button
+          className={cx(
+            "absolute z-10 inline-flex h-6 items-center rounded-md border border-slate-200 bg-white px-2 text-xs font-medium text-slate-600 shadow-sm transition hover:border-violet-200 hover:text-violet-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500",
+            "left-[-2.35rem] top-1/2 -translate-y-1/2",
+          )}
+          type="button"
+          onClick={handleToggleGroupOp}
+        >
+          {label}
+        </button>
+      </div>
+    );
+  },
+  SingleFilter: ({ rule }) => {
+    const { FieldSelect, FilterDataInput, FilterSelect } = useView("templates");
+    const {
+      ruleState: { isValid, parentGroup },
+      removeRule,
+      selectedField,
+    } = useFilterRule(rule);
+
+    const fieldName = String(selectedField?.path[0] ?? "");
+    const FieldIcon = fieldIcons[fieldName] ?? BranchIcon;
+    const canRemove = parentGroup.conditions.length > 1;
+
+    const handleRemoveRule = useCallback(() => {
+      removeRule(true);
+    }, [removeRule]);
+
+    return (
+      <div
+        className={cx(
+          "group/filter-rule flex min-w-0 items-start gap-2",
+          !isValid && "rounded-lg ring-2 ring-amber-300",
+        )}
+      >
+        <div className="flex h-11 w-5 shrink-0 items-center justify-center pt-2 text-slate-400">
+          <GripIcon className="h-4 w-4" />
+        </div>
+        <div className="relative min-w-0 flex-1 rounded-lg border border-slate-200 bg-white shadow-[0_1px_3px_rgba(15,23,42,0.08)]">
+          <div className="relative flex min-w-0 border-b border-slate-200">
+            <div className="flex min-w-0 flex-1 items-center gap-2 px-3">
+              <FieldIcon className="h-4 w-4 shrink-0 text-slate-500" />
+              <FieldSelect
+                aria-label="Field"
+                className="min-w-0 flex-1"
+                rule={rule}
+              />
+            </div>
+            <button
+              aria-label="Remove condition"
+              className="absolute right-1 top-1 flex h-9 w-9 items-center justify-center rounded-md text-slate-400 opacity-0 transition hover:bg-slate-50 hover:text-slate-700 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-violet-500 disabled:pointer-events-none disabled:opacity-0 group-hover/filter-rule:opacity-100"
+              disabled={!canRemove}
+              type="button"
+              onClick={handleRemoveRule}
+            >
+              <CloseIcon className="h-4 w-4" />
+            </button>
+          </div>
+          <div className="grid min-w-0 grid-cols-1 divide-y divide-slate-200 sm:grid-cols-[minmax(110px,0.32fr)_1fr] sm:divide-x sm:divide-y-0">
+            <FilterSelect
+              aria-label="Condition"
+              className="min-w-0"
+              rule={rule}
+            />
+            <FilterDataInput rule={rule} />
+          </div>
+        </div>
+      </div>
+    );
+  },
+} satisfies Partial<FilterTheme["templates"]>;
+
+export const workflowPanelTheme = createFilterTheme({
+  components: componentsSpec,
+  templates: templatesSpec,
+});

--- a/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
+++ b/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
@@ -13,6 +13,7 @@ import {
   type ChangeEvent,
   type ComponentType,
   type InputHTMLAttributes,
+  type MouseEvent,
   type ReactNode,
   type SelectHTMLAttributes,
 } from "react";
@@ -69,13 +70,6 @@ export const BranchIcon = ({ className }: IconProps) => (
 export const ChevronDownIcon = ({ className }: IconProps) => (
   <svg aria-hidden="true" className={className} viewBox="0 0 24 24">
     <path className={iconStroke} d="m6 9 6 6 6-6" />
-  </svg>
-);
-
-const CloseIcon = ({ className }: IconProps) => (
-  <svg aria-hidden="true" className={className} viewBox="0 0 24 24">
-    <path className={iconStroke} d="M18 6 6 18" />
-    <path className={iconStroke} d="m6 6 12 12" />
   </svg>
 );
 
@@ -350,7 +344,6 @@ const templatesSpec = {
       ruleState: { depth, isRoot },
       appendChildGroup,
       appendChildRule,
-      removeGroup,
       toggleGroupOp,
     } = useFilterGroup(rule);
 
@@ -361,10 +354,6 @@ const templatesSpec = {
     const handleAddGroup = useCallback(() => {
       appendChildGroup();
     }, [appendChildGroup]);
-
-    const handleRemoveGroup = useCallback(() => {
-      removeGroup();
-    }, [removeGroup]);
 
     const handleToggleGroupOp = useCallback(() => {
       toggleGroupOp();
@@ -427,14 +416,6 @@ const templatesSpec = {
       >
         {groupRail}
         {groupOperator}
-        <button
-          aria-label="Remove group"
-          className="absolute right-0 top-0 hidden h-7 w-7 items-center justify-center rounded-md text-slate-400 transition hover:bg-slate-100 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 group-hover/filter-group:flex"
-          type="button"
-          onClick={handleRemoveGroup}
-        >
-          <CloseIcon className="h-4 w-4" />
-        </button>
         {children}
       </div>
     );
@@ -448,6 +429,8 @@ const templatesSpec = {
     const { FieldSelect, FilterDataInput, FilterSelect } = useView("templates");
     const {
       ruleState: { parentGroup },
+      appendGroup,
+      appendRule,
       removeRule,
       selectedField,
     } = useFilterRule(rule);
@@ -456,9 +439,33 @@ const templatesSpec = {
     const FieldIcon = fieldIcons[fieldName] ?? BranchIcon;
     const canRemove = parentGroup.conditions.length > 1;
 
-    const handleRemoveRule = useCallback(() => {
-      removeRule(true);
-    }, [removeRule]);
+    const closeMenu = useCallback((event: MouseEvent<HTMLButtonElement>) => {
+      event.currentTarget.closest("details")?.removeAttribute("open");
+    }, []);
+
+    const handleAddCondition = useCallback(
+      (event: MouseEvent<HTMLButtonElement>) => {
+        closeMenu(event);
+        appendRule();
+      },
+      [appendRule, closeMenu],
+    );
+
+    const handleAddGroup = useCallback(
+      (event: MouseEvent<HTMLButtonElement>) => {
+        closeMenu(event);
+        appendGroup();
+      },
+      [appendGroup, closeMenu],
+    );
+
+    const handleRemoveRule = useCallback(
+      (event: MouseEvent<HTMLButtonElement>) => {
+        closeMenu(event);
+        removeRule(true);
+      },
+      [closeMenu, removeRule],
+    );
 
     return (
       <div className="group/filter-rule flex min-w-0 items-start">
@@ -472,15 +479,39 @@ const templatesSpec = {
                 rule={rule}
               />
             </div>
-            <button
-              aria-label="Remove condition"
-              className="absolute right-1 top-1 flex h-9 w-9 items-center justify-center rounded-md text-slate-400 opacity-0 transition hover:bg-slate-50 hover:text-slate-700 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-violet-500 disabled:pointer-events-none disabled:opacity-0 group-hover/filter-rule:opacity-100"
-              disabled={!canRemove}
-              type="button"
-              onClick={handleRemoveRule}
-            >
-              <CloseIcon className="h-4 w-4" />
-            </button>
+            <details className="absolute right-1 top-1 z-30">
+              <summary
+                aria-label="Condition actions"
+                className="flex h-9 w-9 cursor-pointer list-none items-center justify-center rounded-md bg-white text-lg leading-none text-slate-400 opacity-0 transition hover:bg-slate-50 hover:text-slate-700 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-violet-500 group-hover/filter-rule:opacity-100 group-focus-within/filter-rule:opacity-100"
+              >
+                ⋯
+              </summary>
+              <div className="absolute right-0 top-10 w-44 rounded-lg border border-slate-200 bg-white p-1 shadow-lg">
+                <button
+                  className="h-8 w-full rounded-md px-2 text-left text-xs font-medium text-slate-700 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
+                  type="button"
+                  onClick={handleAddCondition}
+                >
+                  Add condition after
+                </button>
+                <button
+                  className="h-8 w-full rounded-md px-2 text-left text-xs font-medium text-slate-700 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
+                  type="button"
+                  onClick={handleAddGroup}
+                >
+                  Add group after
+                </button>
+                <div className="my-1 h-px bg-slate-200" />
+                <button
+                  className="h-8 w-full rounded-md px-2 text-left text-xs font-medium text-red-700 hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 disabled:cursor-not-allowed disabled:text-slate-300 disabled:hover:bg-transparent"
+                  disabled={!canRemove}
+                  type="button"
+                  onClick={handleRemoveRule}
+                >
+                  Delete condition
+                </button>
+              </div>
+            </details>
           </div>
           <div className="grid min-w-0 grid-cols-1 divide-y divide-slate-200 sm:grid-cols-[minmax(110px,0.32fr)_1fr] sm:divide-x sm:divide-y-0">
             <FilterSelect

--- a/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
+++ b/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
@@ -410,11 +410,11 @@ const templatesSpec = {
 
     const hasMultipleConditions = rule.conditions.length > 1;
     const groupRail = hasMultipleConditions ? (
-      <div className="pointer-events-none absolute bottom-4 left-4 top-4 w-6 rounded-l-xl border-y border-l border-slate-200" />
+      <div className="pointer-events-none absolute bottom-4 left-6 top-4 w-4 rounded-l-xl border-y border-l border-slate-200" />
     ) : null;
     const groupOperator = hasMultipleConditions ? (
       <button
-        className="absolute left-4 top-1/2 z-10 inline-flex h-6 -translate-x-1/2 -translate-y-1/2 items-center rounded-md border border-slate-200 bg-white px-2 text-xs font-medium text-slate-600 shadow-sm transition hover:border-violet-200 hover:text-violet-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
+        className="absolute left-6 top-1/2 inline-flex h-6 -translate-x-1/2 -translate-y-1/2 items-center rounded-md border border-slate-200 bg-white px-2 text-xs font-medium text-slate-600 shadow-sm transition hover:border-violet-200 hover:text-violet-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
         type="button"
         onClick={handleToggleGroupOp}
       >

--- a/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
+++ b/packages/docs/src/components/examples/workflow-condition-panel/theme.tsx
@@ -90,15 +90,6 @@ const FolderPlusIcon = ({ className }: IconProps) => (
   </svg>
 );
 
-const GripIcon = ({ className }: IconProps) => (
-  <svg aria-hidden="true" className={className} viewBox="0 0 24 24">
-    <path
-      className="fill-current"
-      d="M9 7.5a1.2 1.2 0 1 1-2.4 0 1.2 1.2 0 0 1 2.4 0Zm0 4.5a1.2 1.2 0 1 1-2.4 0A1.2 1.2 0 0 1 9 12Zm0 4.5a1.2 1.2 0 1 1-2.4 0 1.2 1.2 0 0 1 2.4 0Zm8.4-9a1.2 1.2 0 1 1-2.4 0 1.2 1.2 0 0 1 2.4 0Zm0 4.5a1.2 1.2 0 1 1-2.4 0 1.2 1.2 0 0 1 2.4 0Zm0 4.5a1.2 1.2 0 1 1-2.4 0 1.2 1.2 0 0 1 2.4 0Z"
-    />
-  </svg>
-);
-
 const UserIcon = ({ className }: IconProps) => (
   <svg aria-hidden="true" className={className} viewBox="0 0 24 24">
     <circle className={iconStroke} cx="12" cy="8" r="3" />
@@ -360,6 +351,7 @@ const templatesSpec = {
       appendChildGroup,
       appendChildRule,
       removeGroup,
+      toggleGroupOp,
     } = useFilterGroup(rule);
 
     const handleAddCondition = useCallback(() => {
@@ -374,11 +366,35 @@ const templatesSpec = {
       removeGroup();
     }, [removeGroup]);
 
+    const handleToggleGroupOp = useCallback(() => {
+      toggleGroupOp();
+    }, [toggleGroupOp]);
+
+    const hasMultipleConditions = rule.conditions.length > 1;
+    const groupRail = hasMultipleConditions ? (
+      <div className="pointer-events-none absolute bottom-4 left-4 top-4 w-6 rounded-l-xl border-y border-l border-slate-200" />
+    ) : null;
+    const groupOperator = hasMultipleConditions ? (
+      <button
+        className="absolute left-4 top-1/2 z-10 inline-flex h-6 -translate-x-1/2 -translate-y-1/2 items-center rounded-md border border-slate-200 bg-white px-2 text-xs font-medium text-slate-600 shadow-sm transition hover:border-violet-200 hover:text-violet-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
+        type="button"
+        onClick={handleToggleGroupOp}
+      >
+        {rule.op === "and" ? "And" : "Or"}
+      </button>
+    ) : null;
+
     if (isRoot) {
       return (
         <div {...props}>
-          <div className="relative flex flex-col gap-3 rounded-xl border border-slate-100 bg-slate-50 py-3 pl-10 pr-3">
-            <div className="pointer-events-none absolute bottom-4 left-4 top-4 w-6 rounded-l-xl border-y border-l border-slate-200" />
+          <div
+            className={cx(
+              "relative flex flex-col gap-3 rounded-xl border border-slate-100 bg-slate-50",
+              hasMultipleConditions ? "py-3 pl-12 pr-3" : "p-3",
+            )}
+          >
+            {groupRail}
+            {groupOperator}
             {children}
           </div>
           <div className="mt-5 flex flex-wrap gap-2">
@@ -403,10 +419,14 @@ const templatesSpec = {
 
     return (
       <div
-        className="group/filter-group relative flex flex-col gap-3 rounded-xl border border-slate-100 bg-slate-50 py-3 pl-10 pr-3"
+        className={cx(
+          "group/filter-group relative flex flex-col gap-3 rounded-xl bg-slate-50",
+          hasMultipleConditions ? "py-3 pl-12 pr-3" : "p-3",
+        )}
         {...props}
       >
-        <div className="pointer-events-none absolute bottom-4 left-4 top-4 w-6 rounded-l-xl border-y border-l border-slate-200" />
+        {groupRail}
+        {groupOperator}
         <button
           aria-label="Remove group"
           className="absolute right-0 top-0 hidden h-7 w-7 items-center justify-center rounded-md text-slate-400 transition hover:bg-slate-100 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 group-hover/filter-group:flex"
@@ -423,32 +443,11 @@ const templatesSpec = {
     const PresetFilterSelect = presetTheme.templates.FilterSelect;
     return <PresetFilterSelect tryRetainArgs {...props} />;
   },
-  RuleJoiner: ({ parent }) => {
-    const { toggleGroupOp } = useFilterGroup(parent);
-    const label = parent.op === "and" ? "And" : "Or";
-    const handleToggleGroupOp = useCallback(() => {
-      toggleGroupOp();
-    }, [toggleGroupOp]);
-
-    return (
-      <div className="relative h-2">
-        <button
-          className={cx(
-            "absolute z-10 inline-flex h-6 items-center rounded-md border border-slate-200 bg-white px-2 text-xs font-medium text-slate-600 shadow-sm transition hover:border-violet-200 hover:text-violet-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500",
-            "left-[-2.35rem] top-1/2 -translate-y-1/2",
-          )}
-          type="button"
-          onClick={handleToggleGroupOp}
-        >
-          {label}
-        </button>
-      </div>
-    );
-  },
+  RuleJoiner: () => null,
   SingleFilter: ({ rule }) => {
     const { FieldSelect, FilterDataInput, FilterSelect } = useView("templates");
     const {
-      ruleState: { isValid, parentGroup },
+      ruleState: { parentGroup },
       removeRule,
       selectedField,
     } = useFilterRule(rule);
@@ -462,15 +461,7 @@ const templatesSpec = {
     }, [removeRule]);
 
     return (
-      <div
-        className={cx(
-          "group/filter-rule flex min-w-0 items-start gap-2",
-          !isValid && "rounded-lg ring-2 ring-amber-300",
-        )}
-      >
-        <div className="flex h-11 w-5 shrink-0 items-center justify-center pt-2 text-slate-400">
-          <GripIcon className="h-4 w-4" />
-        </div>
+      <div className="group/filter-rule flex min-w-0 items-start">
         <div className="relative min-w-0 flex-1 rounded-lg border border-slate-200 bg-white shadow-[0_1px_3px_rgba(15,23,42,0.08)]">
           <div className="relative flex min-w-0 border-b border-slate-200">
             <div className="flex min-w-0 flex-1 items-center gap-2 px-3">

--- a/packages/docs/src/content/docs/reference/example.mdx
+++ b/packages/docs/src/content/docs/reference/example.mdx
@@ -46,8 +46,6 @@ import { WorkflowConditionPanel } from "~/components/examples/workflow-condition
   <WorkflowConditionPanel client:load />
 </div>
 <SourceCodeCard path="~/components/examples/workflow-condition-panel/index.tsx" />
-<SourceCodeCard path="~/components/examples/workflow-condition-panel/theme.tsx" />
-<SourceCodeCard path="~/components/examples/workflow-condition-panel/schema.ts" />
 
 ## Backend Integration
 

--- a/packages/docs/src/content/docs/reference/example.mdx
+++ b/packages/docs/src/content/docs/reference/example.mdx
@@ -36,6 +36,19 @@ import { PopoverFilter } from "~/components/examples/popover-filter/index.tsx";
 </div>
 <SourceCodeCard path="~/components/examples/popover-filter/index.tsx" />
 
+## Workflow Condition Panel
+
+This example adapts Filter Sphere into a workflow-builder condition panel with nested groups, operator rails, and compact chip inputs.
+
+import { WorkflowConditionPanel } from "~/components/examples/workflow-condition-panel/index.tsx";
+
+<div className="not-content">
+  <WorkflowConditionPanel client:load />
+</div>
+<SourceCodeCard path="~/components/examples/workflow-condition-panel/index.tsx" />
+<SourceCodeCard path="~/components/examples/workflow-condition-panel/theme.tsx" />
+<SourceCodeCard path="~/components/examples/workflow-condition-panel/schema.ts" />
+
 ## Backend Integration
 
 Filter Sphere is easy to integrate with backend systems. This example demonstrates converting filter rules into SQL WHERE clauses and [Meilisearch](https://www.meilisearch.com/) queries in real time.


### PR DESCRIPTION
## Summary

- add a workflow-style nested condition panel to the examples page
- customize Filter Sphere group, operator, field, and value presentation
- keep group rails limited to multi-condition groups and remove unfinished drag handles
- expose a single source link for the example entry component

## Verification

- pnpm --filter docs run build