### PR TITLE
fix(ci): migrate changesets action inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,7 @@ jobs:
         id: changesets
         uses: changesets/action@v2
         with:
-          publish: "pnpm run release"
-          title: "chore: version packages"
-          commit: "chore: version packages"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          publish-script: "pnpm run release"
+          pr-title: "chore: version packages"
+          commit-message: "chore: version packages"
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- migrate removed `changesets/action@v1` inputs to their `@v2` names
- pass the GitHub token through the supported `github-token` input
- preserve the existing publish command and release PR/commit messages

## Context

`changesets/action@v2` rejects the old `publish`, `title`, and `commit` inputs before the release command runs. This updates the workflow to `publish-script`, `pr-title`, and `commit-message`.

## Verification

- validated configured inputs against the current `changesets/action@v2` action metadata
- `pnpm exec prettier --check .github/workflows/release.yml`
- `pnpm exec vitest run --reporter=dot` (93 tests)
- `pnpm run build`
- `git diff --check`